### PR TITLE
Fix up default values.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -3,8 +3,9 @@ mkdir build
 cd build
 cmake -DMATERIALX_ROOT="/Users/bernardkwok/work/bernard_materialx/build/installed" -GXcode -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
 cmake --build . --target install --config RelWithDebInfo
+
 cd ..
-build/bin/RelWithDebInfo/glTF2Mtlx --gltf build/bin/resources/gltf/BoomBoxWithAxes.gltf --lib /Users/bernardkwok/work/bernard_materialx
+build/bin/RelWithDebInfo/glTF2Mtlx --gltf build/bin/resources/gltf/BoomBoxWithAxes.gltf --lib /Users/bernardkwok/work/bernard_materialx --fullDefinition --assignments
 build/bin/RelWithDebInfo/glTF2Mtlx --mtlx build/bin/resources/gltf/BoomBoxWithAxes.gltf.mtlx --lib /Users/bernardkwok/work/bernard_materialx
 
 cat build/bin/resources/gltf/BoomBoxWithAxes.gltf.mtlx

--- a/resources/gltf/BoomBoxWithAxes.gltf.mtlx._converted.gltf
+++ b/resources/gltf/BoomBoxWithAxes.gltf.mtlx._converted.gltf
@@ -1,0 +1,81 @@
+{
+  "asset": {
+    "generator": "MaterialX 1.38.4 to glTF generator",
+    "version": "1.38",
+    "min_version": "1.38"
+  },
+  "images": [
+    {
+      "name": "image_basecolor",
+      "uri": "BoomBoxWithAxes_baseColor.png"
+    },
+    {
+      "name": "image_orm",
+      "uri": "BoomBoxWithAxes_roughnessMetallic.png"
+    },
+    {
+      "name": "image_normal",
+      "uri": "BoomBoxWithAxes_normal.png"
+    },
+    {
+      "name": "image_emission",
+      "uri": "BoomBoxWithAxes_emissive.png"
+    },
+    {
+      "name": "image_basecolor2",
+      "uri": "BoomBoxWithAxes_baseColor1.png"
+    }
+  ],
+  "materials": [
+    {
+      "name": "M_BoomBox",
+      "pbrMetallicRoughness": {
+        "baseColorTexture": {
+          "index": 0
+        },
+        "metallicRoughnessTexture": {
+          "index": 1
+        }
+      },
+      "normalTexture": {
+        "index": 2
+      },
+      "emissiveTexture": {
+        "index": 3
+      },
+      "emissiveFactor": [1, 1, 1]
+    },
+    {
+      "name": "M_Coordinates",
+      "pbrMetallicRoughness": {
+        "baseColorTexture": {
+          "index": 4
+        },
+        "metallicFactor": 0,
+        "roughnessFactor": 0.735000014
+      }
+    }
+  ],
+  "textures": [
+    {
+      "name": "image_basecolor",
+      "source": 0
+    },
+    {
+      "name": "image_orm",
+      "source": 1
+    },
+    {
+      "name": "image_normal",
+      "source": 2
+    },
+    {
+      "name": "image_emission",
+      "source": 3
+    },
+    {
+      "name": "image_basecolor2",
+      "source": 4
+    }
+  ]
+}

--- a/resources/mtlx/BoomBoxWithAxes.gltf.mtlx
+++ b/resources/mtlx/BoomBoxWithAxes.gltf.mtlx
@@ -1,136 +1,63 @@
 <?xml version="1.0"?>
 <materialx version="1.38">
   <gltf_pbr name="M_BoomBox" type="surfaceshader" nodedef="ND_gltf_pbr_surfaceshader">
-    <input name="base_color" type="color3" value="0.8, 0.8, 0.8" nodename="image_basecolor" />
-    <input name="metallic" type="float" value="0" nodename="extract_metallic" />
-    <input name="roughness" type="float" value="0" nodename="extract_roughness" />
-    <input name="normal" type="vector3" nodename="pbr_normalmap" />
-    <input name="occlusion" type="float" value="0" nodename="extract_occlusion" />
-    <input name="transmission" type="float" value="0" />
-    <input name="specular" type="float" value="1" />
-    <input name="specular_color" type="color3" value="1, 1, 1" />
-    <input name="ior" type="float" value="1.5" />
+    <input name="base_color" type="color3" value="1, 1, 1" nodename="image_basecolor" />
     <input name="alpha" type="float" value="1" />
-    <input name="alpha_mode" type="integer" value="0" />
-    <input name="alpha_cutoff" type="float" value="0.5" />
-    <input name="sheen_color" type="color3" value="0, 0, 0" />
-    <input name="sheen_roughness" type="float" value="0" />
-    <input name="clearcoat" type="float" value="0" />
-    <input name="clearcoat_roughness" type="float" value="0" />
-    <input name="clearcoat_normal" type="vector3" />
-    <input name="emissive" type="color3" value="0, 0, 0" nodename="image_emission" />
-    <input name="emissive_strength" type="float" value="1" />
-    <input name="thickness" type="float" value="0" />
-    <input name="attenuation_distance" type="float" />
-    <input name="attenuation_color" type="color3" value="1, 1, 1" />
+    <input name="metallic" type="float" value="1" nodename="extract_metallic" />
+    <input name="roughness" type="float" value="1" nodename="extract_roughness" />
+    <input name="occlusion" type="float" value="0" nodename="extract_occlusion" />
+    <input name="normal" type="vector3" nodename="pbr_normalmap" />
+    <input name="emissive" type="color3" value="1, 1, 1" nodename="image_emission" />
   </gltf_pbr>
   <surfacematerial name="MATERIAL_M_BoomBox" type="material">
     <input name="surfaceshader" type="surfaceshader" nodename="M_BoomBox" />
   </surfacematerial>
   <tiledimage name="image_basecolor" type="color3" nodedef="ND_image_color3">
     <input name="file" type="filename" value="BoomBoxWithAxes_baseColor.png" colorspace="srgb_texture" />
-    <input name="layer" type="string" value="" />
-    <input name="default" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="texcoord" type="vector2" />
-    <input name="uaddressmode" type="string" value="periodic" />
-    <input name="vaddressmode" type="string" value="periodic" />
-    <input name="filtertype" type="string" value="linear" />
-    <input name="framerange" type="string" value="" />
-    <input name="frameoffset" type="integer" value="0" />
-    <input name="frameendaction" type="string" value="constant" />
   </tiledimage>
   <tiledimage name="image_orm" type="vector3" nodedef="ND_image_vector3">
     <input name="file" type="filename" value="BoomBoxWithAxes_roughnessMetallic.png" />
-    <input name="layer" type="string" value="" />
-    <input name="default" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="texcoord" type="vector2" />
-    <input name="uaddressmode" type="string" value="periodic" />
-    <input name="vaddressmode" type="string" value="periodic" />
-    <input name="filtertype" type="string" value="linear" />
-    <input name="framerange" type="string" value="" />
-    <input name="frameoffset" type="integer" value="0" />
-    <input name="frameendaction" type="string" value="constant" />
   </tiledimage>
   <extract name="extract_occlusion" type="float" nodedef="ND_extract_vector3">
-    <input name="in" type="vector3" value="0.0, 0.0, 0.0" nodename="image_orm" />
+    <input name="in" type="vector3" value="1.0, 1.0, 1.0" nodename="image_orm" />
     <input name="index" type="integer" value="0" />
   </extract>
   <extract name="extract_roughness" type="float" nodedef="ND_extract_vector3">
-    <input name="in" type="vector3" value="0.0, 0.0, 0.0" nodename="image_orm" />
+    <input name="in" type="vector3" value="1.0, 1.0, 1.0" nodename="image_orm" />
     <input name="index" type="integer" value="1" />
   </extract>
   <extract name="extract_metallic" type="float" nodedef="ND_extract_vector3">
-    <input name="in" type="vector3" value="0.0, 0.0, 0.0" nodename="image_orm" />
+    <input name="in" type="vector3" value="1.0, 1.0, 1.0" nodename="image_orm" />
     <input name="index" type="integer" value="2" />
   </extract>
   <tiledimage name="image_normal" type="vector3" nodedef="ND_image_vector3">
     <input name="file" type="filename" value="BoomBoxWithAxes_normal.png" />
-    <input name="layer" type="string" value="" />
-    <input name="default" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="texcoord" type="vector2" />
-    <input name="uaddressmode" type="string" value="periodic" />
-    <input name="vaddressmode" type="string" value="periodic" />
-    <input name="filtertype" type="string" value="linear" />
-    <input name="framerange" type="string" value="" />
-    <input name="frameoffset" type="integer" value="0" />
-    <input name="frameendaction" type="string" value="constant" />
   </tiledimage>
   <normalmap name="pbr_normalmap" type="vector3" nodedef="ND_normalmap">
     <input name="in" type="vector3" value="0.5, 0.5, 1.0" nodename="image_normal" />
-    <input name="space" type="string" value="tangent" />
-    <input name="scale" type="float" value="1.0" />
-    <input name="normal" type="vector3" />
-    <input name="tangent" type="vector3" />
   </normalmap>
   <tiledimage name="image_emission" type="color3" nodedef="ND_image_color3">
     <input name="file" type="filename" value="BoomBoxWithAxes_emissive.png" colorspace="srgb_texture" />
-    <input name="layer" type="string" value="" />
-    <input name="default" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="texcoord" type="vector2" />
-    <input name="uaddressmode" type="string" value="periodic" />
-    <input name="vaddressmode" type="string" value="periodic" />
-    <input name="filtertype" type="string" value="linear" />
-    <input name="framerange" type="string" value="" />
-    <input name="frameoffset" type="integer" value="0" />
-    <input name="frameendaction" type="string" value="constant" />
   </tiledimage>
   <gltf_pbr name="M_Coordinates" type="surfaceshader" nodedef="ND_gltf_pbr_surfaceshader">
-    <input name="base_color" type="color3" value="0.8, 0.8, 0.8" nodename="image_basecolor2" />
+    <input name="base_color" type="color3" value="1, 1, 1" nodename="image_basecolor2" />
+    <input name="alpha" type="float" value="1" />
     <input name="metallic" type="float" value="0" />
     <input name="roughness" type="float" value="0.735" />
-    <input name="normal" type="vector3" />
     <input name="occlusion" type="float" value="0" />
-    <input name="transmission" type="float" value="0" />
-    <input name="specular" type="float" value="1" />
-    <input name="specular_color" type="color3" value="1, 1, 1" />
-    <input name="ior" type="float" value="1.5" />
-    <input name="alpha" type="float" value="1" />
-    <input name="alpha_mode" type="integer" value="0" />
-    <input name="alpha_cutoff" type="float" value="0.5" />
-    <input name="sheen_color" type="color3" value="0, 0, 0" />
-    <input name="sheen_roughness" type="float" value="0" />
-    <input name="clearcoat" type="float" value="0" />
-    <input name="clearcoat_roughness" type="float" value="0" />
-    <input name="clearcoat_normal" type="vector3" />
+    <input name="normal" type="vector3" />
     <input name="emissive" type="color3" value="0, 0, 0" />
-    <input name="emissive_strength" type="float" value="1" />
-    <input name="thickness" type="float" value="0" />
-    <input name="attenuation_distance" type="float" />
-    <input name="attenuation_color" type="color3" value="1, 1, 1" />
   </gltf_pbr>
   <surfacematerial name="MATERIAL_M_Coordinates" type="material">
     <input name="surfaceshader" type="surfaceshader" nodename="M_Coordinates" />
   </surfacematerial>
   <tiledimage name="image_basecolor2" type="color3" nodedef="ND_image_color3">
     <input name="file" type="filename" value="BoomBoxWithAxes_baseColor1.png" colorspace="srgb_texture" />
-    <input name="layer" type="string" value="" />
-    <input name="default" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="texcoord" type="vector2" />
-    <input name="uaddressmode" type="string" value="periodic" />
-    <input name="vaddressmode" type="string" value="periodic" />
-    <input name="filtertype" type="string" value="linear" />
-    <input name="framerange" type="string" value="" />
-    <input name="frameoffset" type="integer" value="0" />
-    <input name="frameendaction" type="string" value="constant" />
   </tiledimage>
+  <look name="look1">
+    <materialassign name="materialassign1" material="MATERIAL_M_Coordinates" collection="collection1" />
+    <materialassign name="materialassign2" material="MATERIAL_M_BoomBox" collection="collection2" />
+  </look>
+  <collection name="collection1" includegeom="/BoomBox_Coordinates/CoordinateSystem, /BoomBox_Coordinates/X_axis, /BoomBox_Coordinates/Y_axis, /BoomBox_Coordinates/Z_axis" />
+  <collection name="collection2" includegeom="/BoomBox_Coordinates/BoomBox" />
 </materialx>

--- a/source/MaterialXglTF/CgtfMaterialLoader.cpp
+++ b/source/MaterialXglTF/CgtfMaterialLoader.cpp
@@ -626,6 +626,11 @@ void CgltfMaterialLoader::setColorInput(DocumentPtr materials, NodePtr shaderNod
             NodePtr newTexture = createTexture(materials, imageNodeName, uri,
                 "color3", "srgb_texture");
             colorInput->setAttribute("nodename", newTexture->getName());
+            // For discussion. Proposal is that value can be used to 
+            // multiply by mapped value. Otherwise there is ambiguity
+            // when both "value" and "nodename" are specified. 
+            //colorInput->removeAttribute("value");
+            colorInput->setValueString(color3Value->getValueString());
         }
         else
         {
@@ -654,6 +659,8 @@ void CgltfMaterialLoader::setFloatInput(DocumentPtr materials, NodePtr shaderNod
             NodePtr newTexture = createTexture(materials, imageNodeName, uri,
                 "float", EMPTY_STRING);
             floatInput->setAttribute("nodename", newTexture->getName());
+            // See above node about "value" + "nodename" both being specified.
+            floatInput->setValue<float>(floatFactor);
         }
         else
         {
@@ -803,8 +810,10 @@ void CgltfMaterialLoader::loadMaterials(void *vdata)
                         extractNode->addInputFromNodeDef("in");
                         extractNode->addInputFromNodeDef("index");
                     }
-                    extractNode->getInput("in")->setAttribute("nodename", textureNode->getName());
-                    extractNode->getInput("in")->setType("vector3");
+                    InputPtr extractInput = extractNode->getInput("in");
+                    extractInput->setAttribute("nodename", textureNode->getName());
+                    extractInput->setType("vector3");
+                    extractInput->setValueString("1.0, 1.0, 1.0");
                     extractNode->getInput("index")->setAttribute("value", std::to_string(i));
                     if (inputs[i])
                     {
@@ -812,6 +821,11 @@ void CgltfMaterialLoader::loadMaterials(void *vdata)
                         inputs[i]->setType("float");
                     }
                 }
+
+                // See note about both "value" and "nodename" being
+                // specified.
+                metallicInput->setValue<float>(roughness.metallic_factor);;
+                roughnessInput->setValue<float>(roughness.roughness_factor);
             }
             else
             {


### PR DESCRIPTION
- Propose: bring up change with TSC to allow for interpretation of both a value + a mapped input to mean to multiply one by the other if it exists. This allows to avoid creating another multiply node to do so.
- Update sample output.
