### PR TITLE
Sidestep string output from MaterialXView capture.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -105,7 +105,7 @@ jobs:
       working-directory: build
 
     - name: CMake Test
-      if: matrix.test_render == 'ON'
+      if: matrix.run_test == 'ON'
       run: ctest -VV --output-on-failure --build-config Release -j1
       working-directory: build
 

--- a/source/glTFMtlxTest/MaterialXglTF/MaterialXglTF.cpp
+++ b/source/glTFMtlxTest/MaterialXglTF/MaterialXglTF.cpp
@@ -149,7 +149,8 @@ TEST_CASE("glTF: Valid glTF -> MTLX", "[gltf]")
                         result.assign(std::istreambuf_iterator<char>(errorStream),
                             std::istreambuf_iterator<char>());
 
-                        if (!result.empty())
+                        bool renderError = returnValue != 0 && !result.empty();
+                        if (renderError)
                         {
                             mx::StringVec errors;
                             std::cout << "- Errors: " << std::endl;
@@ -157,7 +158,7 @@ TEST_CASE("glTF: Valid glTF -> MTLX", "[gltf]")
                             std::cout << "  - Command return code: " + std::to_string(returnValue) << std::endl;
                             std::cout << "  - Log: " << result << std::endl;
                         }
-                        CHECK(result.empty());
+                        CHECK(!renderError);
                     }
                 }
             }


### PR DESCRIPTION
MaterialXView returns strings when performing capture. Also check for… RC=0 to ignore this.